### PR TITLE
Support popover presentation (iOS 8+)

### DIFF
--- a/ActivityView.ios.js
+++ b/ActivityView.ios.js
@@ -19,7 +19,17 @@ var invariant = require('invariant');
  */
 
 var ActivityView = {
-  show: NativeActivityView.show
+  show: (args) => {
+    if (args.popoverSource) {
+      args.popoverSource.measure((x, y, width, height, pageX, pageY) => {
+        delete args.popoverSource;
+        args.sourceFrame = {x: pageX, y: pageY, width, height};
+        NativeActivityView.show(args);
+      });
+    } else {
+      NativeActivityView.show(args);
+    }
+  }
 };
 
 module.exports = ActivityView;

--- a/ActivityView.m
+++ b/ActivityView.m
@@ -48,6 +48,9 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args)
     
     // Display the Activity View
     UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
+    if ([activityView respondsToSelector:@selector(popoverPresentationController)]) {
+        activityView.popoverPresentationController.sourceView = ctrl.view;
+    }
     [ctrl presentViewController:activityView animated:YES completion:nil];
 }
 

--- a/ActivityView.m
+++ b/ActivityView.m
@@ -12,6 +12,7 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args)
     NSURL *url = args[@"url"];
     NSString *imageUrl = args[@"imageUrl"];
     NSString *image = args[@"image"];
+    NSDictionary *sourceFrame = args[@"sourceFrame"];
     NSData * imageData;
     
     // Try to fetch image
@@ -50,6 +51,12 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args)
     UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
     if ([activityView respondsToSelector:@selector(popoverPresentationController)]) {
         activityView.popoverPresentationController.sourceView = ctrl.view;
+        if (sourceFrame != nil) {
+            activityView.popoverPresentationController.sourceRect = CGRectMake([sourceFrame[@"x"] floatValue],
+                                                                               [sourceFrame[@"y"] floatValue],
+                                                                               [sourceFrame[@"width"] floatValue],
+                                                                               [sourceFrame[@"height"] floatValue]);
+        }
     }
     [ctrl presentViewController:activityView animated:YES completion:nil];
 }


### PR DESCRIPTION
Adds an optional `popoverSource` parameter to `show` method. If this parameter is not provided, then the popover will appear from top left corner of the screen for iPads using iOS 8+. When provided, the popover appears from the referenced UI element.

Optionally, one can also define a `sourceFrame` instead of a `popoverSource`.

Fixes #12

## Example

```js
ActivityView.show({
  url: 'https://github.com/',
  popoverSource: this.refs.shareButton,
});
```

![screenshot 2015-08-21 17 17 26](https://cloud.githubusercontent.com/assets/988213/9410361/8c1d7d68-4828-11e5-9cc7-5442bca50907.png)