### PR TITLE
execute on main thread to avoid crash on ios 9

### DIFF
--- a/ActivityView.m
+++ b/ActivityView.m
@@ -3,6 +3,11 @@
 
 @implementation ActivityView
 
+- (dispatch_queue_t)methodQueue
+{
+    return dispatch_get_main_queue();
+}
+
 RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(show:(NSDictionary *)args)


### PR DESCRIPTION
cc @naoufal 

fixes https://github.com/naoufal/react-native-activity-view/issues/15