### PR TITLE
Ability to exclude certain activities, Fixes #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,14 @@ ActivityView.show({
   url: "URL you want to share",
   imageUrl: "Url of the image you want to share/action",
   image: "Name of the image in the app bundle",
+  exclude: ['postToFlickr'],
   anchor: React.findNodeHandle(this.refs.share), // Where you want the share popup to point to on iPad
 });
 ```
 #### Note: 
 - Only provide one image type to the options argument.  If multiple image types are provided, `image` will be used.
 - `anchor` is optional and only applicable for iPad. Popup will be centered by default if `anchor` is not provided.
+- `exclude` is an array with activities you want to exclude from activity view. See [Apple's Documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIActivity_Class/index.html#//apple_ref/doc/constant_group/Built_in_Activity_Types) on Built-in Activity Types for a full list of available values. **Note:** pass only camelcased activity name, e.g. in order to exclude `UIActivityTypePostToFlickr`, pass `postToFlickr` etc.
 
 ## Example
 Using Activity View in your app will usually look like this:
@@ -82,7 +84,7 @@ var YourComponent = React.createClass({
 Displays the Activity View with actions relevant to the `shareObject` passed.
 
 __Arguments__
-- `shareObject` - An _Object_ containing one or more of the following keys `text`, `url`, `anchor`, `imageUrl` or `image`.
+- `shareObject` - An _Object_ containing one or more of the following keys `text`, `url`, `anchor`, `exclude`, `imageUrl` or `image`.
 
 __Examples__
 ```js
@@ -90,6 +92,7 @@ ActivityView.show({
   text: 'ActivityView for React Native',
   url: 'https://github.com/naoufal/react-native-activity-view',
   imageUrl: 'https://facebook.github.io/react/img/logo_og.png',
+  exclude: ['postToFlickr', 'airDrop'],
   anchor: React.findNodeHandle(this.refs.share),
 });
 ```


### PR DESCRIPTION
This pull request implements ability to exclude certain activities. It allows to pass strings with activity names to exclude that are than mapped to native constants. In case unknown string is encountered, warning with a list of available keys is printed accordingly.

Under some circumstances, it's important to exclude unnecessary activities since they can slow down initial load significantly. There are already few reports alarming that `canSendEmail:` blocks activity view for a couple of seconds. It's also not necessary (at least for me), to use AirDrop since I use it mainly for social purposes. AirDrop constant has been added in later iOS versions but I think it should not be an issue since React targets iOS7+ anyways.

Waiting for your feedback guys and ready for squashing.

Testing it in my current project and no issues so far. Seems pretty straight forward.

The only thing that would've been good to handle is what happens when user passes string to `exclude` instead of an array. I think that should be done on the Javascript side before passing to Objective-C. Or we can change the type from NSArray to id and check if it's string, change to array, otherwise, leave it `as is`.

---

Resolves #22