### PR TITLE
schedule activity view in main thread to avoid IO9 issues

### DIFF
--- a/ActivityView.m
+++ b/ActivityView.m
@@ -115,7 +115,11 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args)
             activityView.popoverPresentationController.permittedArrowDirections = 0;
         }
     }
-    [ctrl presentViewController:activityView animated:YES completion:nil];
+
+    // Schedule UI change to run in main thread
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [ctrl presentViewController:activityView animated:YES completion:nil];
+    });
 }
 
 @end


### PR DESCRIPTION
In IOS 9 you'll receive an error if you try to update the UI from the background thread that react-native runs in. 

My change schedules the activity view to be shown from the main thread.

see: http://stackoverflow.com/questions/28302019/getting-a-this-application-is-modifying-the-autolayout-engine-error