### PR TITLE
Allowing for base64ImageData

### DIFF
--- a/ActivityView.m
+++ b/ActivityView.m
@@ -67,18 +67,16 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args)
         }
     }
     
-    
-    // Return if no args were passed
-    if (!text && !url && !image && !imageData && !imageBase64) {
-        RCTLogError(@"[ActivityView] You must specify a text, url, image, base64Image and/or imageUrl.");
-        return;
-    }
-    
     if (imageBase64) {
         imageData = [[NSData alloc] initWithBase64EncodedString:imageBase64 options:NSDataBase64DecodingIgnoreUnknownCharacters];
     }
-
     
+    // Return if no args were passed
+    if (!text && !url && !image && !imageData) {
+        RCTLogError(@"[ActivityView] You must specify a text, url, image, base64Image and/or imageUrl.");
+        return;
+    }
+
     if (text) {
         [shareObject addObject:text];
     }

--- a/ActivityView.m
+++ b/ActivityView.m
@@ -68,12 +68,16 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args)
     }
     
     if (imageBase64) {
-        imageData = [[NSData alloc] initWithBase64EncodedString:imageBase64 options:NSDataBase64DecodingIgnoreUnknownCharacters];
+        @try {
+            imageData = [[NSData alloc] initWithBase64EncodedString:imageBase64 options:NSDataBase64DecodingIgnoreUnknownCharacters];
+        } @catch (NSException *exception) {
+            RCTLogWarn(@"[ActivityView] Could not decode image");
+        }
     }
     
     // Return if no args were passed
     if (!text && !url && !image && !imageData) {
-        RCTLogError(@"[ActivityView] You must specify a text, url, image, base64Image and/or imageUrl.");
+        RCTLogError(@"[ActivityView] You must specify a text, url, image, imageBase64 and/or imageUrl.");
         return;
     }
 

--- a/ActivityView.m
+++ b/ActivityView.m
@@ -70,7 +70,7 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args)
     
     // Return if no args were passed
     if (!text && !url && !image && !imageData && !imageBase64) {
-        RCTLogError(@"[ActivityView] You must specify a text, url, image and/or imageUrl.");
+        RCTLogError(@"[ActivityView] You must specify a text, url, image, base64Image and/or imageUrl.");
         return;
     }
     

--- a/ActivityView.m
+++ b/ActivityView.m
@@ -55,7 +55,8 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args)
     NSString *imageUrl = args[@"imageUrl"];
     NSArray *activitiesToExclude = args[@"exclude"];
     NSString *image = args[@"image"];
-    NSData * imageData;
+    NSString *imageBase64 = args[@"imageBase64"];
+    NSData *imageData;
     
     // Try to fetch image
     if (imageUrl) {
@@ -68,9 +69,13 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args)
     
     
     // Return if no args were passed
-    if (!text && !url && !image && !imageData) {
+    if (!text && !url && !image && !imageData && !imageBase64) {
         RCTLogError(@"[ActivityView] You must specify a text, url, image and/or imageUrl.");
         return;
+    }
+    
+    if (imageBase64) {
+        imageData = [[NSData alloc] initWithBase64EncodedString:imageBase64 options:NSDataBase64DecodingIgnoreUnknownCharacters];
     }
 
     

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ ActivityView.show({
   text: "Text you want to share",
   url: "URL you want to share",
   imageUrl: "Url of the image you want to share/action",
+  imageBase64: "Raw base64 encoded image data"
   image: "Name of the image in the app bundle",
   exclude: ['postToFlickr'],
   anchor: React.findNodeHandle(this.refs.share), // Where you want the share popup to point to on iPad
@@ -84,7 +85,7 @@ var YourComponent = React.createClass({
 Displays the Activity View with actions relevant to the `shareObject` passed.
 
 __Arguments__
-- `shareObject` - An _Object_ containing one or more of the following keys `text`, `url`, `anchor`, `exclude`, `imageUrl` or `image`.
+- `shareObject` - An _Object_ containing one or more of the following keys `text`, `url`, `anchor`, `exclude`, `imageUrl`, `imageBase64`, or `image`.
 
 __Examples__
 ```js
@@ -93,6 +94,15 @@ ActivityView.show({
   url: 'https://github.com/naoufal/react-native-activity-view',
   imageUrl: 'https://facebook.github.io/react/img/logo_og.png',
   exclude: ['postToFlickr', 'airDrop'],
+  anchor: React.findNodeHandle(this.refs.share),
+});
+```
+
+```js
+ActivityView.show({
+  text: 'ActivityView for React Native',
+  imageBase64: 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2...', 
+  exclude: ['airDrop'],
   anchor: React.findNodeHandle(this.refs.share),
 });
 ```


### PR DESCRIPTION
I found a need to submit the base64 image data because the image was not accessible straightforward via url. I could have saved the image locally and worried about deleting it immediately after sharing but this seemed a little easier. 