### PR TITLE
Support custom activities

### DIFF
--- a/ActivityView.m
+++ b/ActivityView.m
@@ -47,6 +47,22 @@ RCT_EXPORT_MODULE()
     return excludedActivities;
 }
 
+- (NSArray*)applicationActivitiesForKeys:(NSArray*)passedKeys
+{
+    NSMutableArray *applicationActivities = [NSMutableArray new];
+    
+    [passedKeys enumerateObjectsUsingBlock:^(NSString *activityName, NSUInteger idx, BOOL *stop) {
+        id customActivity = [self.bridge moduleForName:activityName];
+        if (!customActivity) {
+            RCTLogWarn(@"[ActivityView] Unknown application activity to add: %@", activityName);
+            return;
+        }
+        [applicationActivities addObject:customActivity];
+    }];
+    
+    return applicationActivities;
+}
+
 RCT_EXPORT_METHOD(show:(NSDictionary *)args)
 {
     NSMutableArray *shareObject = [NSMutableArray array];
@@ -54,6 +70,7 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args)
     NSURL *url = args[@"url"];
     NSString *imageUrl = args[@"imageUrl"];
     NSArray *activitiesToExclude = args[@"exclude"];
+    NSArray *customActivitiesToAdd = args[@"customActivities"];
     NSString *image = args[@"image"];
     NSString *imageBase64 = args[@"imageBase64"];
     NSData *imageData;
@@ -95,7 +112,9 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)args)
         [shareObject addObject: [UIImage imageWithData: imageData]];
     }
     
-    UIActivityViewController *activityView = [[UIActivityViewController alloc] initWithActivityItems:shareObject applicationActivities:nil];
+    NSArray *applicationActivities = [self applicationActivitiesForKeys:customActivitiesToAdd];
+    
+    UIActivityViewController *activityView = [[UIActivityViewController alloc] initWithActivityItems:shareObject applicationActivities:applicationActivities];
     
     activityView.excludedActivityTypes = activitiesToExclude
         ? [self excludedActivitiesForKeys:activitiesToExclude]


### PR DESCRIPTION
This pull request adds ability to include custom app specific activities that subclass UIActivity.

To use it, subclass UIActivity (make custom one) and make it react module, example code:

```obj-c
// InstagramActivity.h
#import "RCTBridgeModule.h"
#import <UIKit/UIActivity.h>

@interface InstagramActivity : UIActivity <RCTBridgeModule>

@end
```

```obj-c
// InstagramActivity.m
#import "InstagramActivity.h"
@import UIKit;

@implementation InstagramActivity

@synthesize bridge = _bridge;

RCT_EXPORT_MODULE(InstagramActivity)

- (NSString *)activityType
{
    return @"com.grabbou.whatever";
}

- (NSString *)activityTitle {
    return @"Custom App";
}

- (UIImage *)activityImage {
    return [UIImage imageNamed:@"Logo"];
}

- (BOOL)canPerformWithActivityItems:(NSArray *)activityItems {
    return YES;
}

- (void)prepareWithActivityItems:(NSArray *)activityItems {
}

- (UIViewController *)activityViewController {
    return nil;
}

- (void)performActivity {
    [self activityDidFinish:YES];
}

@end
```

And just call:
```js
ActivityView.show({
   customActivities: ['InstagramActivity']
});
```