### PR TITLE
Use RCTImageLoader

### DIFF
--- a/ActivityView.xcodeproj/project.pbxproj
+++ b/ActivityView.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../react-native/React/**",
+					"$(SRCROOT)/../react-native/Libraries/Image",
 				);
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
@@ -220,6 +221,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../react-native/React/**",
+					"$(SRCROOT)/../react-native/Libraries/Image",
 				);
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";


### PR DESCRIPTION
Fixes #34 

Use RCTImageLoader for fetching images asynchronously (from cache if previously loaded with e.g. Image tag)

That change reduces a delay of 2 seconds the share sheet needs to fetch the image down to `feels immediate` :) Super helpful if you render an image on the same screen with image tag (e.g. gallery) and you click `share`. 

I decided to use the original `show` method to reduce the diff and move the rest to `showWithOptions:image` for clarity.